### PR TITLE
Scala class should implement Handler via mixin when it has super types

### DIFF
--- a/vertx-lang-scala/src/main/resources/vertx-scala/template/class.templ
+++ b/vertx-lang-scala/src/main/resources/vertx-scala/template/class.templ
@@ -61,7 +61,7 @@ import @{importedType}\n
 @comment{"## Inheritance"}
 @if{!superTypes.isEmpty}
 	\n    extends @foreach{superType : classes}@{toScalaType(superType, false)}@if{superType.raw.isConcrete()}(_asJava)@end{}@end{' \n    with '}
-	 @if{!classes.isEmpty() && !abstractClasses.isEmpty()}with @end{}@foreach{superType : abstractClasses}@{toScalaType(superType, false)}@if{superType.raw.isConcrete()}(_asJava)@end{}@end{' \n    with '}
+	 @if{!classes.isEmpty() && !abstractClasses.isEmpty()}with @end{}@foreach{superType : abstractClasses}@{toScalaType(superType, false)}@if{superType.raw.isConcrete()}(_asJava)@end{}@end{' \n    with '}@if{type.isHandler} \n    with io.vertx.core.Handler[@{toScalaType(type.getHandlerArg, false)}]@end{}
 @else{type.isHandler}
 	\n    extends io.vertx.core.Handler[@{toScalaType(type.getHandlerArg, false)}]
 @end{}


### PR DESCRIPTION
Fixes #49

Otherwise we can't compile classes like JsonParser