### PR TITLE
add support for Instants in DataObjects

### DIFF
--- a/vertx-lang-scala/src/main/resources/vertx-scala/template/scala-types.templ
+++ b/vertx-lang-scala/src/main/resources/vertx-scala/template/scala-types.templ
@@ -434,6 +434,8 @@
       return  'Char';
     } else if (type.kind == CLASS_STRING) {
       return  'String';
+    } else if (type.kind == CLASS_INSTANT) {
+      return  'java.time.Instant';
     }
     return 'ERROR typeNameForPrimitiveScala unkown type (' + type + ')';
   }

--- a/vertx-lang-scala/src/main/resources/vertx-scala/template/scala-types.templ
+++ b/vertx-lang-scala/src/main/resources/vertx-scala/template/scala-types.templ
@@ -222,6 +222,8 @@
           ret += ']';
         }
         return ret;
+    } else if (type.kind == CLASS_OTHER && type.name.equals('java.time.Instant')) {
+      return 'java.time.Instant';
     } else {
       return 'Unknown type for toScalaType '+type.name+' '+type.kind;
     }
@@ -332,6 +334,8 @@
         ret = name + '.map(' + name +' => ' + ret + ').orNull';
       }
       return ret;
+    } else if (type.kind == CLASS_OTHER && type.name.equals('java.time.Instant')) {
+      return name + '.asInstanceOf[java.time.Instant]';
     } else {
       return 'Unknown type for toJavaWithConversion '+type.name+' '+type.kind;
     }
@@ -434,8 +438,6 @@
       return  'Char';
     } else if (type.kind == CLASS_STRING) {
       return  'String';
-    } else if (type.kind == CLASS_INSTANT) {
-      return  'java.time.Instant';
     }
     return 'ERROR typeNameForPrimitiveScala unkown type (' + type + ')';
   }

--- a/vertx-lang-scala/src/test/scala/io/vertx/lang/scala/tck/DataObjectTCKTest.scala
+++ b/vertx-lang-scala/src/test/scala/io/vertx/lang/scala/tck/DataObjectTCKTest.scala
@@ -6,6 +6,7 @@ import io.vertx.scala.codegen.testmodel._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FlatSpec, Matchers}
+import java.time.Instant;
 
 /**
   * @author <a href="mailto:jochen.mader@codecentric.de">Jochen Mader</a
@@ -29,6 +30,7 @@ class DataObjectTCKTest extends FlatSpec with Matchers {
     assert(2.2f == dataObject.getFloat("boxedFloatValue"))
     assert(2.22 == dataObject.getDouble("boxedDoubleValue"))
     assert("wibble" == dataObject.getString("stringValue"))
+    assert(Instant.parse("1984-05-27T00:05:00Z") == dataObject.getInstant("instantValue"))
     assert(Json.obj().put("foo", "eek").put("bar", "wibble") == dataObject.getJsonObject("jsonObjectValue"))
     assert(Json.arr("eek", "wibble") == dataObject.getJsonArray("jsonArrayValue"))
     assert("TIM" == dataObject.getString("enumValue"))
@@ -54,6 +56,7 @@ class DataObjectTCKTest extends FlatSpec with Matchers {
       .put("boxedFloatValue", 2.2)
       .put("boxedDoubleValue", 2.22)
       .put("stringValue", "wibble")
+      .put("instantValue", Instant.parse("1984-05-27T00:05:00Z"))
       .put("jsonObjectValue", Json.obj().put("foo", "eek").put("bar", "wibble"))
       .put("jsonArrayValue", Json.arr("eek", "wibble"))
       .put("enumValue", "TIM")
@@ -78,6 +81,8 @@ class DataObjectTCKTest extends FlatSpec with Matchers {
     assert(Json.arr(1.11, 2.22, 3.33) === dataObject.getJsonArray("doubleValues"))
     assert(dataObject.getJsonArray("stringValues") != null)
     assert(Json.arr("stringValues1", "stringValues2", "stringValues3") === dataObject.getJsonArray("stringValues"))
+    assert(dataObject.getJsonArray("instantValues") != null)
+    assert(Json.arr("1984-05-27T00:05:00Z", "2018-07-05T08:23:21Z") == dataObject.getJsonArray("instantValues"))
     assert(dataObject.getJsonArray("jsonObjectValues") != null)
     assert(Json.arr(Json.obj().put("foo", "eek"), Json.obj().put("foo", "wibble")) === dataObject.getJsonArray("jsonObjectValues"))
     assert(dataObject.getJsonArray("jsonArrayValues") != null)
@@ -108,6 +113,7 @@ class DataObjectTCKTest extends FlatSpec with Matchers {
       .put("jsonObjectValues", Json.arr(mapAsJavaMap(Map("foo" -> "eek")), mapAsJavaMap(Map("foo" -> "wibble"))))
       .put("jsonArrayValues", Json.arr(Json.arr("foo"), Json.arr("bar")))
       .put("stringValues", Json.arr("stringValues1", "stringValues2", "stringValues3"))
+      .put("instantValues", Json.arr(Instant.parse("1984-05-27T00:05:00Z"), Instant.parse("2018-07-05T08:23:21Z")))
       .put("dataObjectValues", Json.arr(Json.obj().put("foo", "1").put("bar", 1).put("wibble", 1.1f), Json.obj().put("foo", "2").put("bar", 2).put("wibble", 2.2f)))
       .put("enumValues", Json.arr("TIM", "JULIEN"))
       .put("genEnumValues", Json.arr("BOB", "LAURA")))
@@ -121,6 +127,7 @@ class DataObjectTCKTest extends FlatSpec with Matchers {
     assert(Json.obj().put("1", 123456).put("2", 654321) == dataObject.getJsonObject("integerValues"))
     assert(Json.obj().put("1", 123456789l).put("2", 987654321l) == dataObject.getJsonObject("longValues"))
     assert(Json.obj().put("1", "stringValues1").put("2", "stringValues2") == dataObject.getJsonObject("stringValues"))
+    assert(Json.obj().put("1", Instant.parse("1984-05-27T00:05:00Z")).put("2", Instant.parse("2018-07-05T08:23:21Z")) == dataObject.getJsonObject("instantValues"))
     assert(Json.obj().put("1", Json.obj().put("foo", "eek")).put("2", Json.obj().put("foo", "wibble")) == dataObject.getJsonObject("jsonObjectValues"))
     assert(Json.obj().put("1", Json.arr("foo")).put("2", Json.arr("bar")) == dataObject.getJsonObject("jsonArrayValues"))
     assert("1" == dataObject.getJsonObject("dataObjectValues").getJsonObject("1").getString("foo"))
@@ -143,6 +150,7 @@ class DataObjectTCKTest extends FlatSpec with Matchers {
       .put("floatValues", Json.obj().put("1", 1.1).put("2", 2.2))
       .put("doubleValues", Json.obj().put("1", 1.11).put("2", 2.22))
       .put("stringValues", Json.obj().put("1", "stringValues1").put("2", "stringValues2"))
+      .put("instantValues", Json.obj().put("1", Instant.parse("1984-05-27T00:05:00Z")).put("2", Instant.parse("2018-07-05T08:23:21Z")))
       .put("jsonObjectValues", Json.obj().put("1", Json.obj().put("foo", "eek")).put("2", Json.obj().put("foo", "wibble")))
       .put("jsonArrayValues", Json.obj().put("1", Json.arr("foo")).put("2", Json.arr("bar")))
       .put("dataObjectValues", Json.obj(("1", Json.obj().put("foo", "1").put("bar", 1).put("wibble", 1.1f)), ("2", Json.obj().put("foo", "2").put("bar", 2).put("wibble", 2.2f))))

--- a/vertx-lang-scala/src/test/scala/io/vertx/scala/codegen/testmodel/DataObjectWithListAdders.scala
+++ b/vertx-lang-scala/src/test/scala/io/vertx/scala/codegen/testmodel/DataObjectWithListAdders.scala
@@ -52,6 +52,10 @@ class DataObjectWithListAdders(private val _asJava: JDataObjectWithListAdders) {
     asJava.addGenEnumValue(value)
     this
   }
+  def addInstantValue(value: java.time.Instant) = {
+    asJava.addInstantValue(value.asInstanceOf)
+    this
+  }
   def addIntegerValue(value: Int) = {
     asJava.addIntegerValue(value)
     this

--- a/vertx-lang-scala/src/test/scala/io/vertx/scala/codegen/testmodel/DataObjectWithLists.scala
+++ b/vertx-lang-scala/src/test/scala/io/vertx/scala/codegen/testmodel/DataObjectWithLists.scala
@@ -52,6 +52,10 @@ class DataObjectWithLists(private val _asJava: JDataObjectWithLists) {
     asJava.setGenEnumValues(value.asJava)
     this
   }
+  def setInstantValues(value: scala.collection.mutable.Buffer[java.time.Instant]) = {
+    asJava.setInstantValues(value.asJava)
+    this
+  }
   def setIntegerValues(value: scala.collection.mutable.Buffer[Int]) = {
     asJava.setIntegerValues(value.map(Int.box).asJava)
     this

--- a/vertx-lang-scala/src/test/scala/io/vertx/scala/codegen/testmodel/DataObjectWithMapAdders.scala
+++ b/vertx-lang-scala/src/test/scala/io/vertx/scala/codegen/testmodel/DataObjectWithMapAdders.scala
@@ -52,6 +52,10 @@ class DataObjectWithMapAdders(private val _asJava: JDataObjectWithMapAdders) {
     asJava.addGenEnumValue(key, value)
     this
   }
+  def addInstantValue(key: String, value: java.time.Instant) = {
+    asJava.addInstantValue(key, value.asInstanceOf[java.time.Instant])
+    this
+  }
   def addIntegerValue(key: String, value: Int) = {
     asJava.addIntegerValue(key, value.asInstanceOf[java.lang.Integer])
     this

--- a/vertx-lang-scala/src/test/scala/io/vertx/scala/codegen/testmodel/DataObjectWithMaps.scala
+++ b/vertx-lang-scala/src/test/scala/io/vertx/scala/codegen/testmodel/DataObjectWithMaps.scala
@@ -52,6 +52,10 @@ class DataObjectWithMaps(private val _asJava: JDataObjectWithMaps) {
     asJava.setGenEnumValues(value.asJava)
     this
   }
+  def setInstantValues(value: Map[String, java.time.Instant]) = {
+    asJava.setInstantValues(value.asJava)
+    this
+  }
   def setIntegerValues(value: Map[String, Int]) = {
     asJava.setIntegerValues(value.mapValues(Int.box).asJava)
     this

--- a/vertx-lang-scala/src/test/scala/io/vertx/scala/codegen/testmodel/DataObjectWithValues.scala
+++ b/vertx-lang-scala/src/test/scala/io/vertx/scala/codegen/testmodel/DataObjectWithValues.scala
@@ -76,6 +76,10 @@ class DataObjectWithValues(private val _asJava: JDataObjectWithValues) {
     asJava.setGenEnumValue(value)
     this
   }
+  def setInstantValue(value: java.time.Instant) = {
+    asJava.setInstantValue(value)
+    this
+  }
   def setIntValue(value: Int) = {
     asJava.setIntValue(value)
     this


### PR DESCRIPTION
[This PR](https://github.com/vert-x3/vertx-codegen/pull/195) adds support for `Instant` in `DataObject`s. This one here adds Instant to the scala tests.