### PR TITLE
Try to work on dotty compatibility

### DIFF
--- a/vertx-lang-scala/src/main/scala/io/vertx/lang/scala/ScalaVerticle.scala
+++ b/vertx-lang-scala/src/main/scala/io/vertx/lang/scala/ScalaVerticle.scala
@@ -22,6 +22,7 @@ import io.vertx.core.{AbstractVerticle, Context, Future, Promise, Verticle, Vert
 import scala.util.{Failure, Success}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
 
 /**
@@ -132,7 +133,7 @@ object ScalaVerticle {
   private val Log = ScalaLogger.getLogger(classOf[ScalaVerticle].getName)
   Log.trace("Loaded logger to initialize Json-registration.")
 
-  def nameForVerticle[A <: ScalaVerticle: TypeTag]():String = {
-    "scala:"+implicitly[TypeTag[A]].tpe.typeSymbol.fullName
+  def nameForVerticle[A <: ScalaVerticle: ClassTag]():String = {
+    "scala:"+implicitly[ClassTag[A]].runtimeClass.getTypeName
   }
 }


### PR DESCRIPTION
Motivation:

Las time I checked creating a dotty project with vertx-lang-scala I faced the issue that `TypeTag`  wasn't supported.
I guess just this simple change may be enough to make it work.

Tests are still working (especially the ScalaVerticleTest), but there's a lot still to check, especially performances etc.
