### PR TITLE
Bump Vert.x -> 4.4.6, Scala 3.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <modelVersion>4.0.0</modelVersion>
   <artifactId>vertx-lang-scala3-parent</artifactId>
-  <version>4.4.4-SNAPSHOT</version>
+  <version>4.4.6</version>
   <packaging>pom</packaging>
   <inceptionYear>2016</inceptionYear>
   <organization>
@@ -30,7 +30,7 @@
     </license>
   </licenses>
   <properties>
-    <scala.version>3.3.0</scala.version>
+    <scala.version>3.3.1</scala.version>
     <stack.version>${project.version}</stack.version>
     <asciidoc.dir>${project.basedir}/src/main/asciidoc</asciidoc.dir>
   </properties>
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>2.0.7</version>
+        <version>2.0.9</version>
       </dependency>
       <dependency>
         <groupId>co.helmethair</groupId>
@@ -61,17 +61,17 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.9.2</version>
+        <version>5.10.1</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>5.9.2</version>
+        <version>5.10.1</version>
       </dependency>
       <dependency>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest_3</artifactId>
-        <version>3.2.16</version>
+        <version>3.2.17</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -114,17 +114,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.3.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.6.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.2.2</version>
         </plugin>
         <plugin>
           <groupId>org.scalatest</groupId>

--- a/vertx-lang-scala-codegen/pom.xml
+++ b/vertx-lang-scala-codegen/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-lang-scala3-parent</artifactId>
-    <version>4.4.4-SNAPSHOT</version>
+    <version>4.4.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>vertx-lang-scala-codegen</artifactId>

--- a/vertx-lang-scala-codegen/src/main/java/io/vertx/lang/scala/codegen/ClassCodeGenerator.java
+++ b/vertx-lang-scala-codegen/src/main/java/io/vertx/lang/scala/codegen/ClassCodeGenerator.java
@@ -24,6 +24,7 @@ public class ClassCodeGenerator extends Generator<Model> {
   static {
     List<String> temp = new ArrayList<>();
     temp.add("io.vertx.redis");
+    temp.add("io.vertx.ext.consul.token");
     ignoredPackages = Collections.unmodifiableList(temp);
   }
   public static final List<String> ignoreClassname;

--- a/vertx-lang-scala-itests/pom.xml
+++ b/vertx-lang-scala-itests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-lang-scala3-parent</artifactId>
-    <version>4.4.4-SNAPSHOT</version>
+    <version>4.4.6</version>
   </parent>
 
   <artifactId>vertx-lang-scala-itests</artifactId>

--- a/vertx-lang-scala-test/pom.xml
+++ b/vertx-lang-scala-test/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-lang-scala3-parent</artifactId>
-    <version>4.4.4-SNAPSHOT</version>
+    <version>4.4.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/vertx-lang-scala/pom.xml
+++ b/vertx-lang-scala/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.vertx</groupId>
     <artifactId>vertx-lang-scala3-parent</artifactId>
-    <version>4.4.4-SNAPSHOT</version>
+    <version>4.4.6</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
Motivation:

In preparation for a release, make sure that dependencies are up-to-date and that we are building against the latest version of the Vert.x toolkit.

